### PR TITLE
Add prefix 'sauber_' to image refs where possible

### DIFF
--- a/docker_stack/docker-compose.yml
+++ b/docker_stack/docker-compose.yml
@@ -78,7 +78,7 @@ services:
             - "5440:5432"
 
     lubw_download:
-        image: "lubw_import:latest"
+        image: "sauber_lubw_import:latest"
         networks:
             - network
         volumes:
@@ -122,7 +122,7 @@ services:
 
 
     postgrest_lubw:
-        image: "postgrest:latest"
+        image: "sauber_postgrest:latest"
         networks:
             - network
         secrets:
@@ -148,7 +148,7 @@ services:
             - "3001:3000"
 
     postgrest_here:
-        image: "postgrest:latest"
+        image: "sauber_postgrest:latest"
         networks:
             - network
         secrets:
@@ -193,7 +193,7 @@ services:
             - "9876:9000"
 
     # um_subscriber:
-    #     image: "java-subscribe-download:latest"
+    #     image: "sauber_um_subscriber_demo:latest"
     #     networks:
     #         - network
     #     # secrets:


### PR DESCRIPTION
Add a prefix `sauber_` to the image refs in the `docker-compose.yml` (where possible). This makes it easier to manage our own images later on.