### PR TITLE
Add the traffic visualization demo client to the stack  

### DIFF
--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -49,6 +49,14 @@ secrets:
         name: sauber_manager_password_v1
 
 services:
+
+    proxy-webserver:
+      image: nginx:stable
+      ports:
+        - 80:80
+      volumes:
+        - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+
     db:
         image: "sauber_postgis_alpine"
         networks:

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -50,13 +50,6 @@ secrets:
 
 services:
 
-    proxy-webserver:
-      image: nginx:stable
-      ports:
-        - 80:80
-      volumes:
-        - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
-
     db:
         image: "sauber_postgis_alpine"
         networks:
@@ -119,9 +112,9 @@ services:
             - USE_CORS=1
             - USE_VECTOR_TILES=1
             - EXTRA_JAVA_OPTS=-Xms1g -Xmx2g
-        volumes:
-            - ./geoserver_mnt/geoserver_data:/opt/geoserver_data/:Z
-            - ./geoserver_mnt/additional_libs:/opt/additional_libs/:Z
+        # volumes:
+        #     - ./geoserver_mnt/geoserver_data:/opt/geoserver_data/:Z
+        #     - ./geoserver_mnt/additional_libs:/opt/additional_libs/:Z
         deploy:
             replicas: 1
             restart_policy:
@@ -219,3 +212,24 @@ services:
     #         - um_server
     #     tty:
     #         true  #Keep Container alive, else completes and shuts down
+    #
+
+    traffic-demo-client:
+        image: chrismayer8/traffic-webgis
+        networks:
+            - network
+        ports:
+            - "9000:80"
+        depends_on:
+            - geoserver
+
+    proxy-webserver:
+        image: nginx:stable
+        ports:
+            - "80:80"
+        volumes:
+            - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+        networks:
+            - network
+        depends_on:
+            - geoserver

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -109,8 +109,11 @@ services:
         # secrets:
         environment:
             - USE_CORS=1
+            - USE_VECTOR_TILES=1
+            - EXTRA_JAVA_OPTS=-Xms1g -Xmx2g
         volumes:
-            - geoserver_data:/opt/geoserver_data
+            - ./geoserver_mnt/geoserver_data:/opt/geoserver_data/:Z
+            - ./geoserver_mnt/additional_libs:/opt/additional_libs/:Z
         deploy:
             replicas: 1
             restart_policy:

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -9,7 +9,7 @@ http {
 
       location /geoserver/ {
 
-          proxy_pass http://159.69.72.183:8080/geoserver/;
+          proxy_pass http://geoserver:8080/geoserver/;
 
           if ($request_method = 'OPTIONS') {
             add_header 'Access-Control-Allow-Origin' '*';

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -7,6 +7,12 @@ http {
       listen 80;
       server_name sauber-sdi;
 
+      location /traffic-demo/ {
+
+        proxy_pass http://traffic-demo-client/wegue/;
+
+      }
+
       location /geoserver/ {
 
           proxy_pass http://geoserver:8080/geoserver/;


### PR DESCRIPTION
This PR adds the traffic visualization demo client, which was deployed by the previous docker-compse setup, to the current stack. Also adds a `nginx` proxy server to access the demo client and the GeoServer via port 80.