### PR TITLE
Create HeartbeatChannel on UM Server on deploy

### DIFF
--- a/build-and-start.sh
+++ b/build-and-start.sh
@@ -14,3 +14,9 @@ docker build --rm -f "lubw_import/Dockerfile" -t lubw_download:latest "lubw_impo
 docker build --rm -f "um_ol_demo/Webmap.dockerfile" -t sauber_um_ol_demo:latest "um_ol_demo"
 
 docker stack deploy -c docker-stack.yml sauber-stack
+
+UM_SERVER_ID=`docker ps | grep um_server | cut -c1-5` # Get container ID of UM-Server
+
+if docker inspect -f '{{.State.Running}}' $UM_SERVER_ID > /dev/null ; then # Wait for UM Server to be up and running (State.Running = true)
+    docker exec $UM_SERVER_ID runUMTool.sh CreateChannel -rname=nsp://localhost:9000 -channelname=HeartbeatChannel # Create Heartbeat Channel on UM Server
+fi


### PR DESCRIPTION
Trying to create an existing channel will throw an error, which would be irrelevant here. If this workflow persists, we can either check for existing channels, or send error message to dev/null as well.