### PR TITLE
Convention based naming of Docker images 

### DIFF
--- a/build-and-start.sh
+++ b/build-and-start.sh
@@ -1,35 +1,41 @@
 #/bin/bash
 
+# assemble date and a salt as image version
+DATE=`date +"%Y%m%d"`
+SALT="1"
+# version a la 20200701_1
+IMG_VERSION=$DATE"_"$SALT
+
+echo "USING THE FOLLOWING VERSION FOR IMAGE BUILD "$IMG_VERSION
+
 docker network create sauber-network
 
-docker build --rm -f "db/Dockerfile" -t sauber_postgis_alpine:latest "db"
+docker build --rm -f "db/Dockerfile" -t sauberprojekt/postgis_alpine:$IMG_VERSION "db"
 
-docker build --rm -f "raster_download/Dockerfile" -t raster_download:latest "raster_download"
+docker build --rm -f "raster_download/Dockerfile" -t sauberprojekt/raster_download:$IMG_VERSION "raster_download"
 
-docker build --rm -f "postgrest/Dockerfile" -t sauber_postgrest:latest "postgrest"
+docker build --rm -f "postgrest/Dockerfile" -t sauberprojekt/postgrest:$IMG_VERSION "postgrest"
 
-#docker build --rm -f "postgrest/Dockerfile" -t postgrest_here:latest "postgrest"
+docker build --rm -f "um_ol_demo/Webmap.dockerfile" -t sauberprojekt/um_ol_demo:$IMG_VERSION "um_ol_demo"
 
-docker build --rm -f "um_ol_demo/Webmap.dockerfile" -t sauber_um_ol_demo:latest "um_ol_demo"
-
-docker build --rm -f "um-js-demo-client/Dockerfile" -t sauber_um_js_demo:latest "um-js-demo-client"
+docker build --rm -f "um-js-demo-client/Dockerfile" -t sauberprojekt/um_js_demo:$IMG_VERSION "um-js-demo-client"
 
 docker stack deploy -c docker-stack.yml sauber-stack
 
 CHANNELS=("HeartbeatChannel raster_data station_data") ## Add additional channels to be created
 
 until [ ! -z "$UM_SERVER_ID" ]; do
-    UM_SERVER_ID=`docker ps | grep um_server | cut -c1-5` ## Get all running containers. Search for UM Server container name. Get UM-Server ID by first 5 digits of response. 
+    UM_SERVER_ID=`docker ps | grep um_server | cut -c1-5` ## Get all running containers. Search for UM Server container name. Get UM-Server ID by first 5 digits of response.
     sleep 5;
     ((cnt++)) && ((cnt==6)) && \
     echo 'Error: Universal Messaging Server Container not found.' && \
-    exit # Exit if UM Server not found in given amount of tries 
+    exit # Exit if UM Server not found in given amount of tries
     echo 'Searching for UM Container. Attempt' $cnt;
 done;
 
 for channel in $CHANNELS; do
     echo 'Creating channel' $channel
-    until [ `docker exec $UM_SERVER_ID runUMTool.sh ListChannels -rname=nsp://localhost:9000 | grep $channel` ]; do # Until channel exists on UM Server: 
+    until [ `docker exec $UM_SERVER_ID runUMTool.sh ListChannels -rname=nsp://localhost:9000 | grep $channel` ]; do # Until channel exists on UM Server:
            docker exec $UM_SERVER_ID runUMTool.sh CreateChannel -rname=nsp://localhost:9000 -channelname=$channel # Create channel on UM Server
     sleep 1
     done;

--- a/build-images.sh
+++ b/build-images.sh
@@ -1,0 +1,36 @@
+#/bin/bash
+
+PUSH_TO_HUB=0
+
+# assemble date and a salt as image version
+DATE=`date +"%Y%m%d"`
+SALT="1"
+# version a la 20200701_1
+IMG_VERSION=$DATE"_"$SALT
+
+echo "USING THE FOLLOWING VERSION FOR IMAGE BUILD "$IMG_VERSION
+
+docker build --rm -f "db/Dockerfile" -t sauberprojekt/postgis_alpine:$IMG_VERSION "db"
+
+docker build --rm -f "raster_download/Dockerfile" -t sauberprojekt/raster_download:$IMG_VERSION "raster_download"
+
+docker build --rm -f "postgrest/Dockerfile" -t sauberprojekt/postgrest:$IMG_VERSION "postgrest"
+
+docker build --rm -f "um_ol_demo/Webmap.dockerfile" -t sauberprojekt/um_ol_demo:$IMG_VERSION "um_ol_demo"
+
+docker build --rm -f "um-js-demo-client/Dockerfile" -t sauberprojekt/um_js_demo:$IMG_VERSION "um-js-demo-client"
+
+if [ $PUSH_TO_HUB -eq 1 ]
+then
+  echo "Push images to hub.docker"
+
+  docker push sauberprojekt/postgis_alpine:$IMG_VERSION
+
+  docker push sauberprojekt/raster_download:$IMG_VERSION
+
+  docker push sauberprojekt/postgrest:$IMG_VERSION
+
+  docker push sauberprojekt/um_ol_demo:$IMG_VERSION
+
+  docker push sauberprojekt/um_js_demo:$IMG_VERSION
+fi

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -103,59 +103,6 @@ services:
         ports:
             - "8080:8080"
 
-
-    # postgrest_lubw:
-    #     image: "sauber_postgrest:latest"
-    #     networks:
-    #         - network
-    #     secrets:
-    #         - postgrest_jwt_secret
-    #         - postgrest_password
-    #     environment:
-    #         - PGRST_PASSWORD_FILE=/run/secrets/postgrest_password
-    #         - PGRST_USER=authenticator
-    #         - PGRST_DB_POOL=5
-    #         - PGRST_MAX_ROWS=100
-    #         - PGRST_JWT_SECRET_FILE=/run/secrets/postgrest_jwt_secret
-    #         - PGRST_DB_SERVER=db
-    #         - PGRST_DB_PORT=5432
-    #         - PGRST_DB_NAME=lubw_messstellen
-    #         - PGRST_DB_SCHEMA=daten
-    #         - PGRST_DB_ANON_ROLE=anon
-    #     deploy:
-    #         restart_policy:
-    #          condition: on-failure
-    #     depends_on:
-    #         - db
-    #     ports:
-    #         - "3001:3000"
-
-    # postgrest_here:
-    #     image: "sauber_postgrest:latest"
-    #     networks:
-    #         - sauber-network
-    #     secrets:
-    #         - postgrest_jwt_secret
-    #         - postgrest_password
-    #     environment:
-    #         - PGRST_PASSWORD_FILE=/run/secrets/postgrest_password
-    #         - PGRST_USER=authenticator
-    #         - PGRST_DB_POOL=5
-    #         - PGRST_MAX_ROWS=100
-    #         - PGRST_JWT_SECRET_FILE=/run/secrets/postgrest_jwt_secret
-    #         - PGRST_DB_SERVER=db
-    #         - PGRST_DB_PORT=5432
-    #         - PGRST_DB_NAME=here
-    #         - PGRST_DB_SCHEMA=here_traffic
-    #         - PGRST_DB_ANON_ROLE=anon
-    #     deploy:
-    #         restart_policy:
-    #          condition: on-failure
-    #     depends_on:
-    #         - db
-    #     ports:
-    #         - "3002:3000"
-
     postgrest_raster_publisher:
         image: "sauberprojekt/postgrest:20200701_1"
         networks:
@@ -221,15 +168,6 @@ services:
     #     tty:
     #         true  #Keep Container alive, else completes and shuts down
     #
-
-    traffic-demo-client:
-        image: chrismayer8/traffic-webgis
-        networks:
-            - sauber-network
-        ports:
-            - "9000:80"
-        depends_on:
-            - geoserver
 
     um-ol-demo:
         image: sauberprojekt/um_ol_demo:20200701_1

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -49,7 +49,7 @@ secrets:
 services:
 
     db:
-        image: "sauber_postgis_alpine"
+        image: "sauberprojekt/postgis_alpine:20200701_1"
         networks:
             - sauber-network
         volumes:
@@ -91,7 +91,7 @@ services:
             - EXTRA_JAVA_OPTS=-Xms1g -Xmx2g
         volumes:
             - ./geoserver_mnt/geoserver_data:/opt/geoserver_data/:Z
-            - ./geoserver_mnt/raster_data:/opt/raster_data:Z  
+            - ./geoserver_mnt/raster_data:/opt/raster_data:Z
            # - ./geoserver_mnt/additional_libs:/opt/additional_libs/:Z
            # - raster_data/:/opt/raster_data:Z
         deploy:
@@ -157,7 +157,7 @@ services:
     #         - "3002:3000"
 
     postgrest_raster_publisher:
-        image: "sauber_postgrest:latest"
+        image: "sauberprojekt/postgrest:20200701_1"
         networks:
             - sauber-network
         secrets:
@@ -232,14 +232,14 @@ services:
             - geoserver
 
     um-ol-demo:
-        image: sauber_um_ol_demo:latest
+        image: sauberprojekt/um_ol_demo:20200701_1
         networks:
             - sauber-network
         ports:
             - "9999:80"
 
     um-js-demo:
-        image: sauber_um_js_demo:latest
+        image: sauberprojekt/um_js_demo:20200701_1
         networks:
             - sauber-network
         ports:


### PR DESCRIPTION
This PR ensures that the Docker images in the stack are named after the published ones at hub.docker.io and that these are tied to a specific version. Thefore a the `docker-stack.yml` is adapted.

The `build-and-start.sh` is also changed that the built images are are versioned with the current date and a salt (e.g. `20200701_1`), which is the new convention.

Also adds another shell script `build-images.sh`, which only builds the images and optionally pushed them to hub.docker.io.

Removes unused service in docker-stack in order to clean up the yml file.