### PR TITLE
Use TAG env var for Docker image tags in stack

### DIFF
--- a/build-and-start.sh
+++ b/build-and-start.sh
@@ -4,27 +4,38 @@
 DATE=`date +"%Y%m%d"`
 SALT="1"
 # version a la 20200701_1
-IMG_VERSION=$DATE"_"$SALT
+DATE_TAG=$DATE"_"$SALT
+# the tag for the latest git stage in master branch
+MASTER_TAG="master"
 
-echo "USING THE FOLLOWING VERSION FOR IMAGE BUILD "$IMG_VERSION
+echo "USING THE FOLLOWING TAG FOR IMAGE BUILD "$MASTER_TAG
+echo "USING THE FOLLOWING TAG FOR IMAGE BUILD "$DATE_TAG
 
 docker network create sauber-network
 
-docker build --rm -f "db/Dockerfile" -t sauberprojekt/postgis_alpine:$IMG_VERSION "db"
+docker build --rm -f "db/Dockerfile" -t sauberprojekt/postgis_alpine:$MASTER_TAG "db"
+docker tag sauberprojekt/postgis_alpine:$MASTER_TAG sauberprojekt/postgis_alpine:$DATE_TAG
 
-docker build --rm -f "raster_download/Dockerfile" -t sauberprojekt/raster_download:$IMG_VERSION "raster_download"
+docker build --rm -f "raster_download/Dockerfile" -t sauberprojekt/raster_download:$MASTER_TAG "raster_download"
+docker tag sauberprojekt/raster_download:$MASTER_TAG sauberprojekt/raster_download:$DATE_TAG
 
-docker build --rm -f "json_download/Dockerfile" -t sauberprojekt/json_download:$IMG_VERSION "json_download"
+docker build --rm -f "json_download/Dockerfile" -t sauberprojekt/json_download:$MASTER_TAG "json_download"
+docker tag sauberprojekt/json_download:$MASTER_TAG sauberprojekt/json_download:$DATE_TAG
 
-docker build --rm -f "test_messenger/Dockerfile" -t sauberprojekt/test_messenger:$IMG_VERSION "test_messenger"
+docker build --rm -f "test_messenger/Dockerfile" -t sauberprojekt/test_messenger:$MASTER_TAG "test_messenger"
+docker tag sauberprojekt/test_messenger:$MASTER_TAG sauberprojekt/test_messenger:$DATE_TAG
 
-docker build --rm -f "postgrest/Dockerfile" -t sauberprojekt/postgrest:$IMG_VERSION "postgrest"
+docker build --rm -f "postgrest/Dockerfile" -t sauberprojekt/postgrest:$MASTER_TAG "postgrest"
+docker tag sauberprojekt/postgrest:$MASTER_TAG sauberprojekt/postgrest:$DATE_TAG
 
-docker build --rm -f "geoserver_publisher/Dockerfile" -t sauberprojekt/geoserver_raster_publisher:$IMG_VERSION "geoserver_publisher"
+docker build --rm -f "geoserver_publisher/Dockerfile" -t sauberprojekt/geoserver_raster_publisher:$MASTER_TAG "geoserver_publisher"
+docker tag sauberprojekt/geoserver_raster_publisher:$MASTER_TAG sauberprojekt/geoserver_raster_publisher:$DATE_TAG
 
-docker build --rm -f "um_ol_demo/Webmap.dockerfile" -t sauberprojekt/um_ol_demo:$IMG_VERSION "um_ol_demo"
+docker build --rm -f "um_ol_demo/Webmap.dockerfile" -t sauberprojekt/um_ol_demo:$MASTER_TAG "um_ol_demo"
+docker tag sauberprojekt/um_ol_demo:$MASTER_TAG sauberprojekt/um_ol_demo:$DATE_TAG
 
-docker build --rm -f "um-js-demo-client/Dockerfile" -t sauberprojekt/um_js_demo:$IMG_VERSION "um-js-demo-client"
+docker build --rm -f "um-js-demo-client/Dockerfile" -t sauberprojekt/um_js_demo:$MASTER_TAG "um-js-demo-client"
+docker tag sauberprojekt/um_js_demo:$MASTER_TAG sauberprojekt/um_js_demo:$DATE_TAG
 
 docker stack deploy -c docker-stack.yml sauber-stack
 

--- a/build-images.sh
+++ b/build-images.sh
@@ -6,39 +6,62 @@ PUSH_TO_HUB=0
 DATE=`date +"%Y%m%d"`
 SALT="1"
 # version a la 20200701_1
-IMG_VERSION=$DATE"_"$SALT
+DATE_TAG=$DATE"_"$SALT
+# the tag for the latest git stage in master branch
+MASTER_TAG="master"
 
-echo "USING THE FOLLOWING VERSION FOR IMAGE BUILD "$IMG_VERSION
+echo "USING THE FOLLOWING TAG FOR IMAGE BUILD "$MASTER_TAG
+echo "USING THE FOLLOWING TAG FOR IMAGE BUILD "$DATE_TAG
 
-docker build --rm -f "db/Dockerfile" -t sauberprojekt/postgis_alpine:$IMG_VERSION "db"
+docker build --rm -f "db/Dockerfile" -t sauberprojekt/postgis_alpine:$MASTER_TAG "db"
+docker tag sauberprojekt/postgis_alpine:$MASTER_TAG sauberprojekt/postgis_alpine:$DATE_TAG
 
-docker build --rm -f "raster_download/Dockerfile" -t sauberprojekt/raster_download:$IMG_VERSION "raster_download"
+docker build --rm -f "raster_download/Dockerfile" -t sauberprojekt/raster_download:$MASTER_TAG "raster_download"
+docker tag sauberprojekt/raster_download:$MASTER_TAG sauberprojekt/raster_download:$DATE_TAG
 
-docker build --rm -f "json_download/Dockerfile" -t sauberprojekt/json_download:$IMG_VERSION "json_download"
+docker build --rm -f "json_download/Dockerfile" -t sauberprojekt/json_download:$MASTER_TAG "json_download"
+docker tag sauberprojekt/json_download:$MASTER_TAG sauberprojekt/json_download:$DATE_TAG
 
-docker build --rm -f "test_messenger/Dockerfile" -t sauberprojekt/test_messenger:$IMG_VERSION "test_messenger"
+docker build --rm -f "test_messenger/Dockerfile" -t sauberprojekt/test_messenger:$MASTER_TAG "test_messenger"
+docker tag sauberprojekt/test_messenger:$MASTER_TAG sauberprojekt/test_messenger:$DATE_TAG
 
-docker build --rm -f "postgrest/Dockerfile" -t sauberprojekt/postgrest:$IMG_VERSION "postgrest"
+docker build --rm -f "postgrest/Dockerfile" -t sauberprojekt/postgrest:$MASTER_TAG "postgrest"
+docker tag sauberprojekt/postgrest:$MASTER_TAG sauberprojekt/postgrest:$DATE_TAG
 
-docker build --rm -f "geoserver_publisher/Dockerfile" -t sauberprojekt/geoserver_raster_publisher:$IMG_VERSION "geoserver_publisher"
+docker build --rm -f "geoserver_publisher/Dockerfile" -t sauberprojekt/geoserver_raster_publisher:$MASTER_TAG "geoserver_publisher"
+docker tag sauberprojekt/geoserver_raster_publisher:$MASTER_TAG sauberprojekt/geoserver_raster_publisher:$DATE_TAG
 
-docker build --rm -f "um_ol_demo/Webmap.dockerfile" -t sauberprojekt/um_ol_demo:$IMG_VERSION "um_ol_demo"
+docker build --rm -f "um_ol_demo/Webmap.dockerfile" -t sauberprojekt/um_ol_demo:$MASTER_TAG "um_ol_demo"
+docker tag sauberprojekt/um_ol_demo:$MASTER_TAG sauberprojekt/um_ol_demo:$DATE_TAG
 
-docker build --rm -f "um-js-demo-client/Dockerfile" -t sauberprojekt/um_js_demo:$IMG_VERSION "um-js-demo-client"
+docker build --rm -f "um-js-demo-client/Dockerfile" -t sauberprojekt/um_js_demo:$MASTER_TAG "um-js-demo-client"
+docker tag sauberprojekt/um_js_demo:$MASTER_TAG sauberprojekt/um_js_demo:$DATE_TAG
 
 if [ $PUSH_TO_HUB -eq 1 ]
 then
   echo "Push images to hub.docker"
 
-  docker push sauberprojekt/postgis_alpine:$IMG_VERSION
+  docker push sauberprojekt/postgis_alpine:$MASTER_TAG
+  docker push sauberprojekt/postgis_alpine:$DATE_TAG
 
-  docker push sauberprojekt/raster_download:$IMG_VERSION
+  docker push sauberprojekt/raster_download:$MASTER_TAG
+  docker push sauberprojekt/raster_download:$DATE_TAG
 
-  docker push sauberprojekt/postgrest:$IMG_VERSION
+  docker push sauberprojekt/json_download:$MASTER_TAG
+  docker push sauberprojekt/json_download:$DATE_TAG
 
-  docker push sauberprojekt/geoserver_raster_publisher:$IMG_VERSION
+  docker push sauberprojekt/test_messenger:$MASTER_TAG
+  docker push sauberprojekt/test_messenger:$DATE_TAG
 
-  docker push sauberprojekt/um_ol_demo:$IMG_VERSION
+  docker push sauberprojekt/postgrest:$MASTER_TAG
+  docker push sauberprojekt/postgrest:$DATE_TAG
 
-  docker push sauberprojekt/um_js_demo:$IMG_VERSION
+  docker push sauberprojekt/geoserver_raster_publisher:$MASTER_TAG
+  docker push sauberprojekt/geoserver_raster_publisher:$DATE_TAG
+
+  docker push sauberprojekt/um_ol_demo:$MASTER_TAG
+  docker push sauberprojekt/um_ol_demo:$DATE_TAG
+
+  docker push sauberprojekt/um_js_demo:$MASTER_TAG
+  docker push sauberprojekt/um_js_demo:$DATE_TAG
 fi

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -60,7 +60,7 @@ secrets:
 services:
 
     db:
-        image: "sauberprojekt/postgis_alpine:20201002_1"
+        image: "sauberprojekt/postgis_alpine:${TAG:-master}"
         networks:
             - sauber-network
         volumes:
@@ -90,7 +90,7 @@ services:
             - "5440:5432"
 
     geoserver:
-        image: "meggsimum/geoserver"
+        image: "meggsimum/geoserver:2.17.3"
         networks:
             - sauber-network
         secrets:
@@ -115,7 +115,7 @@ services:
             - "8080:8080"
 
     postgrest_raster_publisher:
-        image: "sauberprojekt/postgrest:20200701_1"
+        image: "sauberprojekt/postgrest:${TAG:-master}"
         networks:
             - sauber-network
         secrets:
@@ -160,7 +160,7 @@ services:
             - "9876:9000"
 
     test_messenger:
-        image: "sauberprojekt/test_messenger:20200722_1"
+        image: "sauberprojekt/test_messenger:${TAG:-master}"
         networks:
             - sauber-network
 #       secrets:
@@ -174,7 +174,7 @@ services:
             true
 
     raster_downloader:
-        image: "sauberprojekt/raster_download:20201001_1"
+        image: "sauberprojekt/raster_download:${TAG:-master}"
         networks:
             - sauber-network
         secrets:
@@ -197,10 +197,10 @@ services:
         volumes:
             - raster_data:/raster_data/:Z
         tty:
-            true 
+            true
 
     json_downloader:
-        image: "sauberprojekt/json_download:20201001_1"
+        image: "sauberprojekt/json_download:${TAG:-master}"
         networks:
             - sauber-network
         secrets:
@@ -227,7 +227,7 @@ services:
             true
 
     geoserver_raster_publisher:
-      image: "sauberprojekt/geoserver_raster_publisher:20200701_1"
+      image: "sauberprojekt/geoserver_raster_publisher:${TAG:-master}"
       networks:
           - sauber-network
       secrets:
@@ -246,14 +246,14 @@ services:
           - geoserver
 
     um-ol-demo:
-        image: sauberprojekt/um_ol_demo:20200701_1
+        image: sauberprojekt/um_ol_demo:${TAG:-master}
         networks:
             - sauber-network
         ports:
             - "9999:80"
 
     um-js-demo:
-        image: sauberprojekt/um_js_demo:20200701_1
+        image: sauberprojekt/um_js_demo:${TAG:-master}
         networks:
             - sauber-network
         ports:


### PR DESCRIPTION
This ensures that the environment variable `TAG` can be used to modify the Docker image tag used for the images in the Docker stack. Default is `"master"`.

Also ensures that in the build scripts for the Docker images a tag `"master"` is set to the images.

So calling the e.g. `stack deploy` command with an env var can change the images used:

`TAG=foobar docker stack deploy -c docker-stack.yml sauber-stack`