### PR TITLE
Remove traffic demo from nginx conf

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -7,12 +7,6 @@ http {
       listen 80;
       server_name sauber-sdi;
 
-      location /traffic-demo/ {
-
-        proxy_pass http://traffic-demo-client/wegue/;
-
-      }
-
       location /geoserver/ {
 
           proxy_pass http://geoserver:8080/geoserver/;


### PR DESCRIPTION
Removes traffic demo setting from nginx configuration since the demo is obsolete.