### PR TITLE
Remove GSPUB_PG_REST_URL to use default REST URL for geoserver_raster…

### DIFF
--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -235,7 +235,6 @@ services:
           - geoserver_user
           - geoserver_password
       environment:
-          - GSPUB_PG_REST_URL=/run/secrets/postgrest_password
           - GSPUB_PG_REST_USER=anon
           - GSPUB_GS_REST_URL=http://geoserver:8080/geoserver/rest/
       deploy:


### PR DESCRIPTION
Remove `GSPUB_PG_REST_URL` environment varibale to use default REST URL for `geoserver_raster_publisher` service.