### PR TITLE
Add WMS-Time viewer to Docker stack

### DIFF
--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -262,6 +262,13 @@ services:
         ports:
             - "9998:80"
 
+    wms-time-viewer:
+        image: sauberprojekt/wms-time-viewer:${TAG:-master}
+        networks:
+            - sauber-network
+        ports:
+            - "9997:80"
+
     proxy-webserver:
         image: nginx:stable
         ports:
@@ -274,6 +281,7 @@ services:
             - geoserver
             - um_server
             - um-js-demo
+            - wms-time-viewer
 
     um-publisher:
         image: um_publisher:latest

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -34,6 +34,33 @@ http {
          }
       }
 
+      location /wms-time-viewer/ {
+
+          proxy_pass http://wms-time-viewer:9997/;
+
+          if ($request_method = 'OPTIONS') {
+            add_header 'Access-Control-Allow-Origin' '*';
+            add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+            #
+            # Custom headers and headers various browsers *should* be OK with but aren't
+            #
+            add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
+            #
+            # Tell client that this pre-flight info is valid for 20 days
+            #
+            add_header 'Access-Control-Max-Age' 1728000;
+            add_header 'Content-Type' 'text/plain; charset=utf-8';
+            add_header 'Content-Length' 0;
+            return 204;
+         }
+         if ($request_method = 'GET') {
+            add_header 'Access-Control-Allow-Origin' '*';
+            add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+            add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
+            add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range';
+         }
+      }
+
       location /um/ {
 
           proxy_pass http://159.69.72.183:9876/;


### PR DESCRIPTION
This adds the WMS-Time WebGIS viewer based on [Wegue](https://github.com/meggsimum/wegue/) to the Docker stack.

Docker image used includes the current demo WMS-Time layer. Can be changed later on by mounting a custom config file.