### PR TITLE
Prepare using SSL in nginx web-proxy

### DIFF
--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -273,8 +273,10 @@ services:
         image: nginx:stable
         ports:
             - "80:80"
+            - "443:443"
         volumes:
             - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+            - /etc/letsencrypt:/etc/ssl/certs:ro
         networks:
             - sauber-network
         depends_on:

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -7,6 +7,17 @@ http {
       listen 80;
       server_name sauber-sdi;
 
+      ### SSL related configs
+
+      #listen              443 ssl;
+      ## adjust your certificate files (incl. path) here
+      #ssl_certificate     /etc/ssl/certs/live/sauber-sdi.meggsimum.de/fullchain.pem;
+      #ssl_certificate_key /etc/ssl/certs/live/sauber-sdi.meggsimum.de/privkey.pem;
+      #ssl_protocols       TLSv1 TLSv1.1 TLSv1.2;
+      #ssl_ciphers         HIGH:!aNULL:!MD5;
+
+      ### END SSL related configs
+
       location /geoserver/ {
 
           proxy_pass http://geoserver:8080/geoserver/;


### PR DESCRIPTION
This prepares the usage of SSL in the nginx-based proxy web server:

- A mount for the certificates to `/etc/ssl/certs` in the docker service is declared and the port 443 is exposed. 
- The nginx configuration for SSL usage is prepared (but commented out) since the certificates have to be in place when launching the nginx service, otherwise it fails.