### PR TITLE
Activate Github Actions for CI

### DIFF
--- a/.github/workflows/ci-sauber-sdi-docker.yml
+++ b/.github/workflows/ci-sauber-sdi-docker.yml
@@ -1,0 +1,27 @@
+# Github Action for CI of sauber-sdi-docker
+name: ci-sauber-sdi-docker
+on:
+  push:
+    branches:
+      - master
+jobs:
+  build-and-push-docker-images:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      # In this step, this action saves a list of existing images,
+      # the cache is created without them in the post run.
+      # It also restores the cache if it exists.
+      - uses: satackey/action-docker-layer-caching@v0.0.11
+      # Ignore the failure of a step and avoid terminating the job.
+        continue-on-error: true
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      # build all images and push to Docker Hub
+      - run: bash ./build-images.sh PUSH_TO_HUB

--- a/build-images.sh
+++ b/build-images.sh
@@ -2,6 +2,11 @@
 
 PUSH_TO_HUB=0
 
+if [ $1 = "PUSH_TO_HUB" ]
+then
+  PUSH_TO_HUB=1
+fi
+
 # assemble date and a salt as image version
 DATE=`date +"%Y%m%d"`
 SALT="1"


### PR DESCRIPTION
This adds a first CI workflow (by Github Actions), which builds all Docker images and pushes them to hub.docker ([sauberprojekt](https://hub.docker.com/u/sauberprojekt) organization). Executed on every push to the master branch. So practically due to branch protection it is only executed when a reviewed PR is merged.

Closes #38
