### PR TITLE
Do not use CORS in GeoServer (handled by proxy instead)

### DIFF
--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -102,7 +102,7 @@ services:
             - geoserver_user
             - geoserver_password
         environment:
-            - USE_CORS=1
+            - USE_CORS=0
             - USE_VECTOR_TILES=1
             - EXTRA_JAVA_OPTS=-Xms1g -Xmx2g
         volumes:


### PR DESCRIPTION
This PR disables CORS for GeoServer on application level. CORS is already handled by the nginx proxy webserver and it should be the only place to handle this. Having it enabled on both sides an error like this occurs:

```
 Response to preflight request doesn't pass access control check: The 'Access-Control-Allow-Origin' header contains multiple values '*, *', but only one is allowed.
```
This might have the drawback that accessing the GeoServer directly does not supoport COIRS anymore. But accessing directly is no good idea and should not be doe anyway :stuck_out_tongue_closed_eyes: 

Fixes #55 