### PR TITLE
Fix GeoServer admin GUI usage behind reverse proxy

### DIFF
--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -105,6 +105,7 @@ services:
             - USE_CORS=0
             - USE_VECTOR_TILES=1
             - EXTRA_JAVA_OPTS=-Xms1g -Xmx2g
+            - GEOSERVER_CSRF_WHITELIST=sauber-sdi.meggsimum.de
         volumes:
             - ./geoserver_mnt/geoserver_data:/opt/geoserver_data/:Z
             - ./geoserver_mnt/raster_data:/opt/raster_data:Z


### PR DESCRIPTION
This adds the env var `GEOSERVER_CSRF_WHITELIST` to the docker service config for GeoServer. By setting the deploy domain, the GeoServer admin GUI gets fully working behind the reverse proxy. Check [here](https://docs.geoserver.org/latest/en/user/security/webadmin/csrf.html) for more information.

Fixes #58 