### PR TITLE
Fix CWD in cronjob execution of 'geoserver_raster_publisher'

### DIFF
--- a/geoserver_publisher/cronjob/config
+++ b/geoserver_publisher/cronjob/config
@@ -3,4 +3,4 @@
 
 # execute the node script every minute
 # TODO set to 5 mins for test server
-*/2 * * * * node /opt/index.js >> /opt/log_raster_publisher.txt 2>&1
+*/2 * * * * cd /opt && node ./index.js >> /opt/log_raster_publisher.txt 2>&1


### PR DESCRIPTION
This ensures that the current working directory has the correct value when the `geoserver_raster_publisher` node script (`index.js`) is executed as cronjob.