### PR TITLE
Install missing 'zip' in geoserver_raster_publisher

### DIFF
--- a/geoserver_publisher/Dockerfile
+++ b/geoserver_publisher/Dockerfile
@@ -3,8 +3,10 @@ LABEL maintainer="chris@meggsimum.de"
 
 
 # install git to resolve git based dependency in package.json
-RUN apk add --no-cache git
+# install zip to pack *.properties files for ImageMosaic GS Store
+RUN apk add --no-cache git zip
 RUN git --version
+RUN zip --version
 
 COPY  /package.json /opt/package.json
 


### PR DESCRIPTION
Installs the missing 'zip' program in the `geoserver_raster_publisher` Docker Image.

Partly for #82 