### PR TITLE
geoserver_init: Split change GS credentials and GS init script

### DIFF
--- a/geoserver_init/000_change-auth.js
+++ b/geoserver_init/000_change-auth.js
@@ -1,0 +1,66 @@
+import GeoServerRestClient from 'geoserver-node-client';
+import dockerSecret from './js-utils/docker-secrets.js';
+
+const verbose = process.env.GSINIT_VERBOSE;
+
+const geoserverUrl = 'http://geoserver:8080/geoserver/rest/';
+const geoserverDefaultUser = 'admin';
+const geoserverDefaultPw = 'geoserver';
+const role = 'ADMIN';
+
+verboseLogging('GeoServer REST URL: ', geoserverUrl);
+verboseLogging('GeoServer Default REST User:', geoserverDefaultUser);
+verboseLogging('GeoServer Default REST PW:  ', geoserverDefaultPw);
+
+// read GS login from secrets
+const newGeoserverUser = dockerSecret.read('geoserver_user');
+const newGeoserverPw = dockerSecret.read('geoserver_password');
+
+/**
+ * Adapts security settings for GeoServer
+ */
+async function adaptSecurity () {
+  const user = newGeoserverUser;
+  const userPw = newGeoserverPw;
+
+  if (!user || !userPw || user === '' || userPw === '') {
+    console.error('No valid user or user password given - EXIT.');
+  }
+
+  const userCreated = await grc.security.createUser(user, userPw);
+  if (userCreated) {
+    console.info('Successfully created user', user);
+  }
+
+  const roleAssigend = await grc.security.associateUserRole(user, role);
+  if (roleAssigend) {
+    console.info(`Successfully added role ${role} to user ${user}`);
+  }
+
+  // disable user
+  const adminDisabled = await grc.security.updateUser(geoserverDefaultUser, geoserverDefaultPw, false);
+  if (adminDisabled) {
+    console.info('Successfully disabled default "admin" user');
+  }
+}
+
+/**
+ * logging util
+ * @param {*} _msg Message to log in verbose mode
+ */
+// eslint-disable-next-line no-unused-vars
+function verboseLogging(msg) {
+  if (verbose) {
+    console.log.apply(console, arguments);
+  }
+}
+
+// check if we can connect to GeoServer REST API
+const grc = new GeoServerRestClient(geoserverUrl, geoserverDefaultUser, geoserverDefaultPw);
+grc.exists().then(gsExists => {
+  if (gsExists === true) {
+    adaptSecurity();
+  } else {
+    console.error('Could not connect to GeoServer REST API - seems like auth has been changed in this setup!');
+  }
+});

--- a/geoserver_init/Dockerfile
+++ b/geoserver_init/Dockerfile
@@ -14,7 +14,8 @@ RUN npm install --only=production
 # copy JS sources
 COPY  /js-utils/logging.js /opt/js-utils/logging.js
 COPY  /js-utils/docker-secrets.js /opt/js-utils/docker-secrets.js
-COPY  /index.js /opt/index.js
+COPY  /000_change-auth.js /opt/000_change-auth.js
+COPY  /010_init-gs.js /opt/010_init-gs.js
 COPY  /wait-for.sh /opt/wait-for.sh
 
 RUN chmod +x /opt/wait-for.sh

--- a/geoserver_init/package.json
+++ b/geoserver_init/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "index.js",
   "scripts": {
-    "start": "node index.js",
+    "start": "node 000_change-auth.js && node 010_init-gs.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [


### PR DESCRIPTION
This splits changing the default GeoServer credentials and initializing GeoServer data (e.g. workspaces, etc.) into separate scripts.

Otherwise once the credentials have been changed the `geoserver_init` script is not runnable anymore.