### PR TITLE
Add creation of fv_stations layer in geoserver_init

### DIFF
--- a/geoserver_init/package-lock.json
+++ b/geoserver_init/package-lock.json
@@ -482,8 +482,8 @@
       "dev": true
     },
     "geoserver-node-client": {
-      "version": "git+https://github.com/chrismayer/geoserver-node-client.git#827a75dbdb38e2deda6e88af656466d8d76651cd",
-      "from": "git+https://github.com/chrismayer/geoserver-node-client.git#master",
+      "version": "git+https://github.com/meggsimum/geoserver-node-client.git#37f0d1bb7692728c47d6573c0734b7db18932d81",
+      "from": "git+https://github.com/meggsimum/geoserver-node-client.git#master",
       "requires": {
         "node-fetch": "^2.6.1"
       }


### PR DESCRIPTION
This adds the automatic creation of the GeoServer layer `'station_data:fv_stations'` in the `geoserver_init` service.

_Can only be merged once #94 is finalized._

Closes #95 