### PR TITLE
Replace ENV VAR 'MASTER_TAG' by 'TAG' in build sh scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Docker setup for the SDI of the [SAUBER](https://sauber-projekt.de) project.
 
 ## Start Setup
 
-Prerequisites: [Docker](https://www.docker.com/) and [Docker Stack](https://docs.docker.com/engine/reference/commandline/stack/) have to be installed on your target plattform.
+Prerequisites: [Docker](https://www.docker.com/) and [Docker Stack](https://docs.docker.com/engine/reference/commandline/stack/) have to be installed on your target platform.
 
   - Clone or download this repository
   - Navigate to the checkout / download in a terminal, e.g.
@@ -18,3 +18,37 @@ Prerequisites: [Docker](https://www.docker.com/) and [Docker Stack](https://docs
     ```
     docker stack deploy -c docker-stack.yml sauber-stack-local
     ```
+
+## Prod Setup
+
+In order to fire up the SDI on a production machine or you want to simulate this on your local machine we provide some helper scripts.
+Execute the following:
+
+```bash
+# starts the setup with the latest images from Docker Hub
+# see https://hub.docker.com/u/sauberprojekt
+./build-and-start.sh SKIPBUILD
+
+```
+
+## Dev Setup
+
+### Build and Start
+
+In case you want to fire up the SDI setup with local images, which are explicitly built for the dev setup execute the following:
+
+```bash
+# build all images locally with the tag 'foobar' and starts the setup
+TAG=foobar ./build-and-start.sh
+```
+
+**CAUTION: This can take some time since all images are built**
+
+### Build only
+
+Build all images of the stack locally with the given tag (default is master):
+
+```bash
+# build all images locally with the tag 'foobar'
+TAG=foobar ./build-images.sh
+```

--- a/build-and-start.sh
+++ b/build-and-start.sh
@@ -13,10 +13,10 @@ DATE=`date +"%Y%m%d"`
 SALT="1"
 # version a la 20200701_1
 DATE_TAG=$DATE"_"$SALT
-# the tag for the latest git stage in master branch
-MASTER_TAG="master"
+# tag for the docker images (default "master" for latest stage in master branch)
+TAG="${TAG:-master}"
 
-echo "USING THE FOLLOWING TAG FOR IMAGE BUILD "$MASTER_TAG
+echo "USING THE FOLLOWING TAG FOR IMAGE BUILD "$TAG
 echo "USING THE FOLLOWING TAG FOR IMAGE BUILD "$DATE_TAG
 
 docker network create sauber-network
@@ -26,7 +26,7 @@ then
 
   echo "Building Docker Images ..."
 
-  /bin/sh ./build-images.sh
+  TAG="$TAG" /bin/sh ./build-images.sh
 
   echo "... DONE Building Docker Images"
 

--- a/build-images.sh
+++ b/build-images.sh
@@ -12,79 +12,79 @@ DATE=`date +"%Y%m%d"`
 SALT="1"
 # version a la 20200701_1
 DATE_TAG=$DATE"_"$SALT
-# the tag for the latest git stage in master branch
-MASTER_TAG="master"
+# tag for the docker images (default "master" for latest stage in master branch)
+TAG="${TAG:-master}"
 
-echo "USING THE FOLLOWING TAG FOR IMAGE BUILD "$MASTER_TAG
+echo "USING THE FOLLOWING TAG FOR IMAGE BUILD "$TAG
 echo "USING THE FOLLOWING TAG FOR IMAGE BUILD "$DATE_TAG
 
-docker build --rm -f "db/Dockerfile" -t sauberprojekt/db:$MASTER_TAG "db"
-docker tag sauberprojekt/db:$MASTER_TAG sauberprojekt/db:$DATE_TAG
+docker build --rm -f "db/Dockerfile" -t sauberprojekt/db:$TAG "db"
+docker tag sauberprojekt/db:$TAG sauberprojekt/db:$DATE_TAG
 
-docker build --rm -f "raster_download/Dockerfile" -t sauberprojekt/raster_download:$MASTER_TAG "raster_download"
-docker tag sauberprojekt/raster_download:$MASTER_TAG sauberprojekt/raster_download:$DATE_TAG
+docker build --rm -f "raster_download/Dockerfile" -t sauberprojekt/raster_download:$TAG "raster_download"
+docker tag sauberprojekt/raster_download:$TAG sauberprojekt/raster_download:$DATE_TAG
 
-docker build --rm -f "json_download/Dockerfile" -t sauberprojekt/json_download:$MASTER_TAG "json_download"
-docker tag sauberprojekt/json_download:$MASTER_TAG sauberprojekt/json_download:$DATE_TAG
+docker build --rm -f "json_download/Dockerfile" -t sauberprojekt/json_download:$TAG "json_download"
+docker tag sauberprojekt/json_download:$TAG sauberprojekt/json_download:$DATE_TAG
 
-docker build --rm -f "lanuv_download/Dockerfile" -t sauberprojekt/lanuv_download:$MASTER_TAG "lanuv_download"
-docker tag sauberprojekt/lanuv_download:$MASTER_TAG sauberprojekt/lanuv_download:$DATE_TAG
+docker build --rm -f "lanuv_download/Dockerfile" -t sauberprojekt/lanuv_download:$TAG "lanuv_download"
+docker tag sauberprojekt/lanuv_download:$TAG sauberprojekt/lanuv_download:$DATE_TAG
 
-docker build --rm -f "lubw_download/Dockerfile" -t sauberprojekt/lubw_download:$MASTER_TAG "lubw_Download"
-docker tag sauberprojekt/lubw_download:$MASTER_TAG sauberprojekt/lubw_download:$DATE_TAG
+docker build --rm -f "lubw_download/Dockerfile" -t sauberprojekt/lubw_download:$TAG "lubw_Download"
+docker tag sauberprojekt/lubw_download:$TAG sauberprojekt/lubw_download:$DATE_TAG
 
-docker build --rm -f "test_messenger/Dockerfile" -t sauberprojekt/test_messenger:$MASTER_TAG "test_messenger"
-docker tag sauberprojekt/test_messenger:$MASTER_TAG sauberprojekt/test_messenger:$DATE_TAG
+docker build --rm -f "test_messenger/Dockerfile" -t sauberprojekt/test_messenger:$TAG "test_messenger"
+docker tag sauberprojekt/test_messenger:$TAG sauberprojekt/test_messenger:$DATE_TAG
 
-docker build --rm -f "postgrest/Dockerfile" -t sauberprojekt/postgrest:$MASTER_TAG "postgrest"
-docker tag sauberprojekt/postgrest:$MASTER_TAG sauberprojekt/postgrest:$DATE_TAG
+docker build --rm -f "postgrest/Dockerfile" -t sauberprojekt/postgrest:$TAG "postgrest"
+docker tag sauberprojekt/postgrest:$TAG sauberprojekt/postgrest:$DATE_TAG
 
-docker build --rm -f "geoserver_publisher/Dockerfile" -t sauberprojekt/geoserver_raster_publisher:$MASTER_TAG "geoserver_publisher"
-docker tag sauberprojekt/geoserver_raster_publisher:$MASTER_TAG sauberprojekt/geoserver_raster_publisher:$DATE_TAG
+docker build --rm -f "geoserver_publisher/Dockerfile" -t sauberprojekt/geoserver_raster_publisher:$TAG "geoserver_publisher"
+docker tag sauberprojekt/geoserver_raster_publisher:$TAG sauberprojekt/geoserver_raster_publisher:$DATE_TAG
 
-docker build --rm -f "station_layer_creator/Dockerfile" -t sauberprojekt/station_layer_creator:$MASTER_TAG "station_layer_creator"
-docker tag sauberprojekt/station_layer_creator:$MASTER_TAG sauberprojekt/station_layer_creator:$DATE_TAG
+docker build --rm -f "station_layer_creator/Dockerfile" -t sauberprojekt/station_layer_creator:$TAG "station_layer_creator"
+docker tag sauberprojekt/station_layer_creator:$TAG sauberprojekt/station_layer_creator:$DATE_TAG
 
-docker build --rm -f "um_ol_demo/Webmap.dockerfile" -t sauberprojekt/um_ol_demo:$MASTER_TAG "um_ol_demo"
-docker tag sauberprojekt/um_ol_demo:$MASTER_TAG sauberprojekt/um_ol_demo:$DATE_TAG
+docker build --rm -f "um_ol_demo/Webmap.dockerfile" -t sauberprojekt/um_ol_demo:$TAG "um_ol_demo"
+docker tag sauberprojekt/um_ol_demo:$TAG sauberprojekt/um_ol_demo:$DATE_TAG
 
-docker build --rm -f "um-js-demo-client/Dockerfile" -t sauberprojekt/um_js_demo:$MASTER_TAG "um-js-demo-client"
-docker tag sauberprojekt/um_js_demo:$MASTER_TAG sauberprojekt/um_js_demo:$DATE_TAG
+docker build --rm -f "um-js-demo-client/Dockerfile" -t sauberprojekt/um_js_demo:$TAG "um-js-demo-client"
+docker tag sauberprojekt/um_js_demo:$TAG sauberprojekt/um_js_demo:$DATE_TAG
 
-docker build --rm -f "geoserver_init/Dockerfile" -t sauberprojekt/geoserver_init:$MASTER_TAG "geoserver_init"
-docker tag sauberprojekt/geoserver_init:$MASTER_TAG sauberprojekt/geoserver_init:$DATE_TAG
+docker build --rm -f "geoserver_init/Dockerfile" -t sauberprojekt/geoserver_init:$TAG "geoserver_init"
+docker tag sauberprojekt/geoserver_init:$TAG sauberprojekt/geoserver_init:$DATE_TAG
 
 if [ $PUSH_TO_HUB -eq 1 ]
 then
   echo "Push images to hub.docker"
 
-  docker push sauberprojekt/db:$MASTER_TAG
+  docker push sauberprojekt/db:$TAG
   docker push sauberprojekt/db:$DATE_TAG
 
-  docker push sauberprojekt/raster_download:$MASTER_TAG
+  docker push sauberprojekt/raster_download:$TAG
   docker push sauberprojekt/raster_download:$DATE_TAG
 
-  docker push sauberprojekt/json_download:$MASTER_TAG
+  docker push sauberprojekt/json_download:$TAG
   docker push sauberprojekt/json_download:$DATE_TAG
 
-  docker push sauberprojekt/test_messenger:$MASTER_TAG
+  docker push sauberprojekt/test_messenger:$TAG
   docker push sauberprojekt/test_messenger:$DATE_TAG
 
-  docker push sauberprojekt/postgrest:$MASTER_TAG
+  docker push sauberprojekt/postgrest:$TAG
   docker push sauberprojekt/postgrest:$DATE_TAG
 
-  docker push sauberprojekt/geoserver_raster_publisher:$MASTER_TAG
+  docker push sauberprojekt/geoserver_raster_publisher:$TAG
   docker push sauberprojekt/geoserver_raster_publisher:$DATE_TAG
 
-  docker push sauberprojekt/station_layer_creator:$MASTER_TAG
+  docker push sauberprojekt/station_layer_creator:$TAG
   docker push sauberprojekt/station_layer_creator:$DATE_TAG
 
-  docker push sauberprojekt/um_ol_demo:$MASTER_TAG
+  docker push sauberprojekt/um_ol_demo:$TAG
   docker push sauberprojekt/um_ol_demo:$DATE_TAG
 
-  docker push sauberprojekt/um_js_demo:$MASTER_TAG
+  docker push sauberprojekt/um_js_demo:$TAG
   docker push sauberprojekt/um_js_demo:$DATE_TAG
 
-  docker push sauberprojekt/geoserver_init:$MASTER_TAG
+  docker push sauberprojekt/geoserver_init:$TAG
   docker push sauberprojekt/geoserver_init:$DATE_TAG
 fi


### PR DESCRIPTION
This replaces the hard coded var 'MASTER_TAG' by the env var `TAG` in the build bash scripts. So the tag for the Docker images can be modified from outside and the `TAG` env var used in the `docker-stack.yml` can be reused.
The default is `'master' `as it was the hard coded value before, so no functional change at all (if nothing else is configured).

This allows to build and fire up the Docker stack with a consitent TAG for all Docker images by executing:

`TAG=kalle ./build-and-start.sh`

Very helpful for local dev setup or publishing all images with a dedicated tag. 