### PR TITLE
geoserver_init: prevent repeating restart

### DIFF
--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -140,6 +140,8 @@ services:
             - GSINIT_PROXY_BASE_URL=https://sauber-sdi.meggsimum.de/geoserver
         deploy:
             replicas: 1
+            restart_policy:
+                condition: on-failure
         depends_on:
             - geoserver
         command: ["./wait-for.sh", "geoserver:8080", "--", "npm", "start"]


### PR DESCRIPTION
fixes #106 

The service `geoserver_init` repeatedly restarts it self. This is not required, it has to run only once, since it only initializes the GeoServer.

Adapting the `docker-stack.yml` like this fixes the problem.

```
        deploy:
            replicas: 1
            restart_policy:
                condition: on-failure
```

Removing the `deploy` tag completely did not have any effect on the continuous restarting. 
 