### PR TITLE
Wait for GeoServer and PostgREST to start geoserver_init

### DIFF
--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -144,7 +144,7 @@ services:
                 condition: on-failure
         depends_on:
             - geoserver
-        command: ["./wait-for.sh", "geoserver:8080", "--", "npm", "start"]
+        command: ["./wait-for.sh", "geoserver:8080", "postgrest_raster_publisher:3000", "--", "npm", "start"]
 
     postgrest_raster_publisher:
         image: "sauberprojekt/postgrest:${TAG:-master}"


### PR DESCRIPTION
This modifies the wait-for.sh script in the `geoserver_init` service, so it checks for a running GeoServer and a running PostgREST server in our stack. Only the it makes sense to start the init script for the GeoServer.

Fixes #133 