### PR TITLE
Fix build for raster_download Docker image

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -7,6 +7,8 @@ then
   PUSH_TO_HUB=1
 fi
 
+echo "PUSH_TO_HUB="$PUSH_TO_HUB
+
 # assemble date and a salt as image version
 DATE=`date +"%Y%m%d"`
 SALT="1"

--- a/raster_download/Dockerfile
+++ b/raster_download/Dockerfile
@@ -1,5 +1,6 @@
 FROM postgis/postgis:12-3.0-alpine as pgis
 COPY resources/copy_pg_bins.sh /.
+RUN chmod +x /copy_pg_bins.sh
 RUN /copy_pg_bins.sh
 
 FROM maven:3.6.0-jdk-8-slim


### PR DESCRIPTION
This ensures that the Docker image `raster_download` can be built. Since the build failed in github actions it is more than outdated in our  registry at hub.docker (see https://hub.docker.com/r/sauberprojekt/raster_download)