### PR TITLE
Inject 'sauber_manager_password' secret into 'geoserver_raster_publisher

### DIFF
--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -304,6 +304,7 @@ services:
           - postgrest_password
           - geoserver_user
           - geoserver_password
+          - sauber_manager_password
       environment:
           - GSPUB_PG_REST_USER=anon
           - GSPUB_GS_REST_URL=http://geoserver:8080/geoserver/rest/


### PR DESCRIPTION
Adds the secret `sauber_manager_password` into the service `geoserver_raster_publisher`, so the DB password in the `datastore.properties` can be set correctly. 