### PR TITLE
Improve raster publication service 

### DIFF
--- a/geoserver_publisher/cronjob/config
+++ b/geoserver_publisher/cronjob/config
@@ -1,6 +1,3 @@
-# only for dev testing, TODO remove
-* * * * * echo "hello cronjob" >> /opt/log_cron_test.txt 2>&1
-
 # execute the node script every minute
 # TODO set to 5 mins for test server
-*/2 * * * * cd /opt && node ./index.js >> /opt/log_raster_publisher.txt 2>&1
+*/2 * * * * cd /opt && node ./index.js

--- a/geoserver_publisher/index.js
+++ b/geoserver_publisher/index.js
@@ -174,10 +174,23 @@ async function createRasterTimeLayers (rasterMetaInf) {
 
   } else {
     verboseLogging(`Layer "${ws}:${layerName}" already existing.`);
+  }
 
-    //TODO check if TIME already set
+  // check if layer has time dimension enabled
+  let hasTime = false;
+  const coverage = await grc.layers.getCoverage(ws, covStore, layerName);
+  if (coverage && coverage.coverage.metadata && coverage.coverage.metadata.entry &&
+    coverage.coverage.metadata.entry['@key'] === 'time' && (typeof coverage.coverage.metadata.entry.dimensionInfo === 'object')) {
+      const dimInfo = coverage.coverage.metadata.entry.dimensionInfo;
+      if (dimInfo.enabled === true && dimInfo.nearestMatchEnabled === true &&
+          dimInfo.acceptableInterval) {
+          hasTime = true;
+      }
+  }
+
+  if (!hasTime) {
     console.info(`Enabling time for layer "${ws}:${layerName}"`);
-    const timeEnabled = await grc.layers.enableTimeCoverage(ws, covStore, layerName, 'DISCRETE_INTERVAL', 3600000, 'MAXIMUM');
+    const timeEnabled = await grc.layers.enableTimeCoverage(ws, covStore, layerName, 'DISCRETE_INTERVAL', 3600000, 'MAXIMUM', true, false, 'PT30M');
     verboseLogging(`Time dimension  for layer "${ws}:${layerName}" successfully enabled?`, timeEnabled);
   }
 }

--- a/geoserver_publisher/package-lock.json
+++ b/geoserver_publisher/package-lock.json
@@ -490,9 +490,9 @@
       "dev": true
     },
     "geoserver-node-client": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/geoserver-node-client/-/geoserver-node-client-0.0.3.tgz",
-      "integrity": "sha512-Vpzf5DdFiRcsfFDDY4KZoXbng2T7SojiT+dWlie7wxedB3OkltB3frK1Z+J9d7Hm7H7e3k1X6mIWMcKMZtbPqw==",
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/geoserver-node-client/-/geoserver-node-client-0.0.4.tgz",
+      "integrity": "sha512-eBy3JGqy/V3tjWzGuuUXQwpPSUzA46ek2huISzhciAw0EWHiIryzq2AgwI2XTjPAiaZO+Xb/apmeVZUQZd9Zlg==",
       "requires": {
         "node-fetch": "^2.6.1"
       }

--- a/geoserver_publisher/package.json
+++ b/geoserver_publisher/package.json
@@ -18,7 +18,7 @@
   "author": "C. Mayer (meggsimum)",
   "license": "MIT",
   "dependencies": {
-    "geoserver-node-client": "0.0.3",
+    "geoserver-node-client": "0.0.4",
     "node-fetch": "^2.6.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This adds several improvements for the `raster_publication` service:

  - Enable nearest match and set acceptable interval for time dimension in the GeoServer raster layer
  - Only set time dimension if not already set on the GeoServer layer
  - Also enable time dimension when GeoServer layer is created (before only set, if it was existing)
  - Do not log to file in cronjob, so the logs should appear in the container logs.