### PR TITLE
Remove outdated 'wms-time-viewer' service from stack

### DIFF
--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -348,13 +348,6 @@ services:
     #     ports:
     #         - "9998:80"
 
-    wms-time-viewer:
-        image: sauberprojekt/wms-time-viewer:${TAG:-master}
-        networks:
-            - sauber-network
-        ports:
-            - "9997:80"
-
     proxy-webserver:
         image: nginx:stable
         ports:
@@ -369,7 +362,6 @@ services:
             - geoserver
             - um_server
             - um-js-demo
-            - wms-time-viewer
 
     # can be commented in for local debugging, no use in production
     # um-publisher:


### PR DESCRIPTION
This removes the `wms-time-viewer` service based on an outdated image from the Docker stack.

The WMS-Time demonstrator is now available under https://sauber-projekt.meggsimum.de/wms-time-viewer/?time=2021-08-26T21:00 to demonstrate the decentralized usage of our SDI.