### PR TITLE
Mount DB backups to host sys

### DIFF
--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -69,6 +69,7 @@ services:
             - sauber-network
         volumes:
             - db_data:/var/lib/postgresql/data
+            - ./db_backups:/home/backups/database/postgresql
         secrets:
             - postgrest_jwt_secret
             - postgrest_password


### PR DESCRIPTION
In order to keep the backup files in case the DB container stops working. 
Notwithstanding possible implementation of different pg_backup workflow.