### PR TITLE
Add access to out-DB raster data for DB

### DIFF
--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -70,6 +70,7 @@ services:
         volumes:
             - db_data:/var/lib/postgresql/data
             - ./geoserver_mnt/raster_data:/opt/raster_data:ro
+            - ./db_backups:/home/backups/database/postgresql
         secrets:
             - postgrest_jwt_secret
             - postgrest_password

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -69,6 +69,7 @@ services:
             - sauber-network
         volumes:
             - db_data:/var/lib/postgresql/data
+            - ./geoserver_mnt/raster_data:/opt/raster_data:ro
         secrets:
             - postgrest_jwt_secret
             - postgrest_password


### PR DESCRIPTION
Now that rasters are saved as out-DB rasters in the Geoserver instance, make them accessible to the DB instance, for possible in-DB calculations. 

Read-only as no write access should be necessary, thus avoid any R/W conflicts.