### PR TITLE
Simple check for DB backup size

### DIFF
--- a/db/resources/bin/pg_backup.sh
+++ b/db/resources/bin/pg_backup.sh
@@ -96,13 +96,6 @@ function perform_backups()
 				mv $FINAL_BACKUP_DIR"$DATABASE".sql.gz.in_progress $FINAL_BACKUP_DIR"$DATABASE".sql.gz
 			fi
 			set +o pipefail
-
-			if (( $(stat -c%s $FINAL_BACKUP_DIR"$DATABASE".sql.gz) > 10000000 )); then
-				echo "Deleting outdated backups"
-				delete_outdated
-			else 
-				echo "[!!WARNING!!] Backup smaller than 10MB. Keeping old Backups. Check backup $FINAL_BACKUP_DIR"$DATABASE".sql.gz" 1>&2
-			fi
 		fi
 
 		if [ $ENABLE_CUSTOM_BACKUPS = "yes" ]
@@ -116,6 +109,16 @@ function perform_backups()
 			fi
 		fi
 
+		# Assume at least 10MB for successful backup
+		MIN_BYTE_COUNT=10000000 
+
+		if [ $(stat -c%s $FINAL_BACKUP_DIR"$DATABASE".sql.gz) > MIN_BYTE_COUNT ]; then
+			echo "Deleting outdated backups"
+			delete_outdated
+		else 
+			echo "[!!WARNING!!] Backup smaller than 10MB. Keeping old Backups. Check backup $FINAL_BACKUP_DIR"$DATABASE".sql.gz" 1>&2
+		fi
+
 	done
 
 	echo -e "\nAll database backups complete!"
@@ -125,7 +128,6 @@ function delete_outdated()
 {
 	# MONTHLY BACKUPS
 
-	echo "DELETE OUTDATED --------------------------------"
 	DAY_OF_MONTH=`date +%d`
 
 	if [ $DAY_OF_MONTH -eq 1 ];

--- a/db/resources/bin/pg_backup.sh
+++ b/db/resources/bin/pg_backup.sh
@@ -112,7 +112,7 @@ function perform_backups()
 		# Assume at least 10MB for successful backup
 		MIN_BYTE_COUNT=10000000 
 
-		if [ $(stat -c%s $FINAL_BACKUP_DIR"$DATABASE".sql.gz) > MIN_BYTE_COUNT ]; then
+		if [ $(stat -c%s $FINAL_BACKUP_DIR"$DATABASE".sql.gz) > $MIN_BYTE_COUNT ]; then
 			echo "Deleting outdated backups"
 			delete_outdated
 		else 

--- a/db/resources/bin/pg_backup.sh
+++ b/db/resources/bin/pg_backup.sh
@@ -112,7 +112,7 @@ function perform_backups()
 		# Assume at least 10MB for successful backup
 		MIN_BYTE_COUNT=10000000 
 
-		if [ $(stat -c%s $FINAL_BACKUP_DIR"$DATABASE".sql.gz) > $MIN_BYTE_COUNT ]; then
+		if [ $(stat -c%s $FINAL_BACKUP_DIR"$DATABASE".sql.gz) -gt $MIN_BYTE_COUNT ]; then
 			echo "Deleting outdated backups"
 			delete_outdated
 		else 

--- a/db/resources/bin/pg_backup.sh
+++ b/db/resources/bin/pg_backup.sh
@@ -96,7 +96,13 @@ function perform_backups()
 				mv $FINAL_BACKUP_DIR"$DATABASE".sql.gz.in_progress $FINAL_BACKUP_DIR"$DATABASE".sql.gz
 			fi
 			set +o pipefail
-                        
+
+			if (( $(stat -c%s $FINAL_BACKUP_DIR"$DATABASE".sql.gz) > 10000000 )); then
+				echo "Deleting outdated backups"
+				delete_outdated
+			else 
+				echo "[!!WARNING!!] Backup smaller than 10MB. Keeping old Backups. Check backup $FINAL_BACKUP_DIR"$DATABASE".sql.gz" 1>&2
+			fi
 		fi
 
 		if [ $ENABLE_CUSTOM_BACKUPS = "yes" ]
@@ -115,38 +121,42 @@ function perform_backups()
 	echo -e "\nAll database backups complete!"
 }
 
-# MONTHLY BACKUPS
+function delete_outdated()
+{
+	# MONTHLY BACKUPS
 
-DAY_OF_MONTH=`date +%d`
+	echo "DELETE OUTDATED --------------------------------"
+	DAY_OF_MONTH=`date +%d`
 
-if [ $DAY_OF_MONTH -eq 1 ];
-then
-	# Delete all expired monthly directories
-	find $BACKUP_DIR -maxdepth 1 -name "*-monthly" -exec rm -rf '{}' ';'
-	        	
-	perform_backups "-monthly"
-	
-	exit 0;
-fi
+	if [ $DAY_OF_MONTH -eq 1 ];
+	then
+		# Delete all expired monthly directories
+		find $BACKUP_DIR -maxdepth 1 -name "*-monthly" -exec rm -rf '{}' ';'
+					
+		perform_backups "-monthly"
+		
+		exit 0;
+	fi
 
-# WEEKLY BACKUPS
+	# WEEKLY BACKUPS
 
-DAY_OF_WEEK=`date +%u` #1-7 (Monday-Sunday)
-EXPIRED_DAYS=`expr $((($WEEKS_TO_KEEP * 7) + 1))`
+	DAY_OF_WEEK=`date +%u` #1-7 (Monday-Sunday)
+	EXPIRED_DAYS=`expr $((($WEEKS_TO_KEEP * 7) + 1))`
 
-if [ $DAY_OF_WEEK = $DAY_OF_WEEK_TO_KEEP ];
-then
-	# Delete all expired weekly directories
-	find $BACKUP_DIR -maxdepth 1 -mtime +$EXPIRED_DAYS -name "*-weekly" -exec rm -rf '{}' ';'
-	        	
-	perform_backups "-weekly"
-	
-	exit 0;
-fi
+	if [ $DAY_OF_WEEK = $DAY_OF_WEEK_TO_KEEP ];
+	then
+		# Delete all expired weekly directories
+		find $BACKUP_DIR -maxdepth 1 -mtime +$EXPIRED_DAYS -name "*-weekly" -exec rm -rf '{}' ';'
+					
+		perform_backups "-weekly"
+		
+		exit 0;
+	fi
 
-# DAILY BACKUPS
+	# DAILY BACKUPS
 
-# Delete daily backups 7 days old or more
-find $BACKUP_DIR -maxdepth 1 -mtime +$DAYS_TO_KEEP -name "*-daily" -exec rm -rf '{}' ';'
+	# Delete daily backups 7 days old or more
+	find $BACKUP_DIR -maxdepth 1 -mtime +$DAYS_TO_KEEP -name "*-daily" -exec rm -rf '{}' ';'
+}
 
 perform_backups "-daily"


### PR DESCRIPTION
Check if created backup is > 10MB
If not: print warning, do not trigger new wrapper function to delete outdated backups (+7 days for daily updates)

Could be expanded by checking against previous update file, however built-in busybox date tools do not support relative dates -> Would need to change Dockerfile itself.