### PR TITLE
Remove obsolete time-viewer config for nginx

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -45,33 +45,6 @@ http {
          }
       }
 
-      location /wms-time-viewer/ {
-
-          proxy_pass http://wms-time-viewer:9997/;
-
-          if ($request_method = 'OPTIONS') {
-            add_header 'Access-Control-Allow-Origin' '*';
-            add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
-            #
-            # Custom headers and headers various browsers *should* be OK with but aren't
-            #
-            add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
-            #
-            # Tell client that this pre-flight info is valid for 20 days
-            #
-            add_header 'Access-Control-Max-Age' 1728000;
-            add_header 'Content-Type' 'text/plain; charset=utf-8';
-            add_header 'Content-Length' 0;
-            return 204;
-         }
-         if ($request_method = 'GET') {
-            add_header 'Access-Control-Allow-Origin' '*';
-            add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
-            add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
-            add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range';
-         }
-      }
-
       location /um/ {
 
           proxy_pass http://159.69.72.183:9876/;


### PR DESCRIPTION
Since the time-viewer is no more part of the stack in order to show the decentralized character of the platform the corresponding nginx config is removed with this.