### PR TITLE
RasterDownloader: Handle simulation rasters

### DIFF
--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -217,10 +217,14 @@ services:
             - hhi_rest_user
             - hhi_rest_pw
             - hhi_ip_address
+            - geoserver_user
+            - geoserver_password
         environment:
             - APP_PASSWORD_FILE=/run/secrets/app_password
             - HHI_REST_USER_FILE=/run/secrets/hhi_rest_user
             - HHI_REST_PASSWORD_FILE=/run/secrets/hhi_rest_password
+            - GEOSERVER_USER_FILE=/run/secrets/geoserver_user
+            - GEOSERVER_PASSWORD_FILE=/run/secrets/geoserver_password
             - DB_USER=app
             - UM_CHANNEL=raster_data
             - UM_SERVER=um_server:9000

--- a/raster_download/src/main/java/de/meggsimum/sauber/sdi/RasterDownloader.java
+++ b/raster_download/src/main/java/de/meggsimum/sauber/sdi/RasterDownloader.java
@@ -536,7 +536,7 @@
 				System.exit(1);
 		}
 
-		/*
+		/**
 		 * Workaround to publish simulation rasters with current and simulated land use
 		 * For incoming GeoTIFFs with "type:sim..", create coverage and publish layer 
 		 * Build URL to GS REST API for external (existing, no upload) GeoTIFF

--- a/raster_download/src/main/java/de/meggsimum/sauber/sdi/RasterDownloader.java
+++ b/raster_download/src/main/java/de/meggsimum/sauber/sdi/RasterDownloader.java
@@ -289,7 +289,7 @@
 				
 				if (category.contains("forecast")) {
 					evtPrefix = "fc_";
-				} else if (category.contains("sim")) {
+				} else if (category.startsWith("sim")) {
 					// build event prefix as e.g. "sim_current_"
 					evtPrefix = category.replace("-", "_");
 					evtPrefix += "_";

--- a/raster_download/src/main/java/de/meggsimum/sauber/sdi/RasterDownloader.java
+++ b/raster_download/src/main/java/de/meggsimum/sauber/sdi/RasterDownloader.java
@@ -539,7 +539,6 @@
 		 * Use parameter coverageStore for name of CovStore, Layer
 		 * Need to PUT only path to file as body, already downloaded by downloadRaster()
 		 */
-		
 		private void createRasterSimLayer(String coverageStore, String filePath) throws IOException {
 
 			String base_url = "http://geoserver:8080/geoserver/rest/workspaces/simulation/coveragestores/";
@@ -557,7 +556,7 @@
 			con.setRequestProperty("Connection", "Keep-Alive");
 			con.setDoOutput(true);
 			con.setRequestProperty("Content-Type", "text/plain");
-			con.setRequestProperty  ("Authorization", "Basic " + authEncoded);
+			con.setRequestProperty("Authorization", "Basic " + authEncoded);
 			con.setConnectTimeout(HTTP_TIMEOUT);
 			
 			byte[] out = filePath.getBytes(StandardCharsets.UTF_8);
@@ -598,7 +597,7 @@
 			con.setRequestProperty("Connection", "Keep-Alive");
 			con.setDoOutput(true);
 			con.setRequestProperty("Content-Type", "text/xml");
-			con.setRequestProperty  ("Authorization", "Basic " + authEncoded);
+			con.setRequestProperty("Authorization", "Basic " + authEncoded);
 			con.setConnectTimeout(HTTP_TIMEOUT);
 
 			byte[] out = LayerTitle.getBytes(StandardCharsets.UTF_8);

--- a/raster_download/src/main/java/de/meggsimum/sauber/sdi/RasterDownloader.java
+++ b/raster_download/src/main/java/de/meggsimum/sauber/sdi/RasterDownloader.java
@@ -288,16 +288,21 @@
 				
 				
 				if (category.contains("forecast")) {
-					evtPrefix = "fc";
+					evtPrefix = "fc_";
 				} else if (category.contains("sim")) {
+					// build event prefix as e.g. "sim_current_"
 					evtPrefix = category.replace("-", "_");
+					evtPrefix += "_";
+					
+					// build scenario string to insert into store name as "scenario_"
 					scenario = evtData.getString("scenario"); // decided to move to outer JSON
+					scenario += "_";
 				} else {
 					System.out.println("Error: Could not determine if forecast / simulation.");
 					System.exit(1);
 				}
 	
-				fileName = evtPrefix + "_" + fileName;
+				fileName = evtPrefix + fileName;
 				URL requestUrl = new URL(request);
 				InetAddress requestAddress = InetAddress.getByName(requestUrl.getHost());
 				String requestIP = requestAddress.getHostAddress();
@@ -389,7 +394,7 @@
 					evtPrefix = ""; 					
 				}
 				
-				String coverageName = evtPrefix + "_" + evtRegion.toLowerCase() + "_" + scenario + "_" + evtPollutant.toLowerCase();
+				String coverageName = evtPrefix + evtRegion.toLowerCase() + "_" + scenario + evtPollutant.toLowerCase();
 				
 				String outDir = "/opt/raster_data/"+ coverageName + "/";
 	

--- a/raster_download/src/main/java/de/meggsimum/sauber/sdi/RasterDownloader.java
+++ b/raster_download/src/main/java/de/meggsimum/sauber/sdi/RasterDownloader.java
@@ -582,7 +582,7 @@
 			}
 		}
 
-		 /* 
+		/**
 		 * Adjust layer title, which is created from filename incl. timestamp  
 		 * PUT small String of xml to new layer via REST API, containing Coverage Store name
 		 */


### PR DESCRIPTION
If raster metadata contains `{"type":"sim-..."}`, publish in single coverage store -> raster layer on GeoServer instance.
The idea is to publish current and changed land use in pairs. 
Name created from 
1. `sim-current/sim-changed` prefix 
1. region
1. new parameter `{"scenario":"location_#"}`
1. pollutant 

E.g. sim_change_heidelberg_bahnhof_3_co2