### PR TITLE
Add creation of 'db_backups' directory

### DIFF
--- a/build-and-start.sh
+++ b/build-and-start.sh
@@ -42,6 +42,14 @@ mkdir \
 echo "... DONE Creating mount directory for GeoServer"
 echo
 
+# create mount directory for database backups
+echo
+echo "Creating mount directory for database backups"
+mkdir \
+  db_backups
+echo "... DONE Creating mount directory for database backups"
+echo
+
 docker stack deploy -c docker-stack.yml sauber-stack
 
 echo 'Waiting 60 seconds for stack to deploy...'


### PR DESCRIPTION
Extend the `build-and-start.sh` script to create a directory for `db_backups`. Otherwise the database container fails on a fresh system.