### PR TITLE
Upgrade GeoServer to version 2.19.3

### DIFF
--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -98,7 +98,7 @@ services:
             - "5440:5432"
 
     geoserver:
-        image: "meggsimum/geoserver:2.19.1"
+        image: "meggsimum/geoserver:2.19.3"
         networks:
             - sauber-network
         secrets:


### PR DESCRIPTION
Upgrades GeoServer in the stack to latest maintenance version 2.19.3.