### PR TITLE
Update 003_create_component_views.sql

### DIFF
--- a/db/update-files.d/003_create_component_views.sql
+++ b/db/update-files.d/003_create_component_views.sql
@@ -38,7 +38,7 @@ BEGIN
 	     JOIN station_data.lut_component co_1 ON tp.fk_component = co_1.idpk_component
 	     JOIN station_data.lut_station s_1 ON tp.fk_station = s_1.idpk_station
 	  WHERE co_1.component_name = %2$L::text
-	  ORDER BY tp.date_time DESC;           
+	  ORDER BY tp.date_time DESC, tp.offset_hrs ASC;           
       GRANT SELECT ON station_data.agg_prediction_%1$s TO app;
 	', replace(lower(component_name),'-','_'), component_name);
 		
@@ -101,7 +101,7 @@ BEGIN
 			             JOIN station_data.lut_component co_1 ON tp.fk_component = co_1.idpk_component
 			             JOIN station_data.lut_station s_1 ON tp.fk_station = s_1.idpk_station
 			          WHERE s_1.station_code = %3$L AND co_1.component_name = %4$L
-			          ORDER BY tp.date_time DESC
+			          ORDER BY tp.date_time DESC, tp.offset_hrs ASC
 			        )
 			 SELECT row_number() OVER () AS idpk,
 			    sel.fk_component AS component_id,


### PR DESCRIPTION
# Problem

For every prediction row (combination of station+componen+timestamp) multiple entries exist because they overlap, since we receive a 48 hour set of predictions every day.
So I used `SELECT DISTINCT ON (tp.date_time)... ORDER BY tp.date_time DESC`. 
DISTINCT ON selects the first occurence in the given DISTINCT collection, thus only one record per time stamp. 
Issue: The ascending ordering by offset hours (hours until prediction is valid) is not implicit. 
So, different rows from "old" and "new" set of predictions can be selected.

# Solution

Need to explicitly order by offset_hrs to pick only one row for each timestamp, and the latest prediction.
Thus that `SELECT DISTINCT ON ...` explicitly sees: 

| idpk | station | pollutant | timestamp           | <ins>offset_hrs</ins> |
|------|---------|-----------|---------------------|------------|
| 49   | 1       | 1         | 01-01-2000 00:00:00 | <ins>1</ins>          |
| 1    | 1       | 1         | 01-01-2000 00:00:00 | 48         |

and picks the first occurence = latest prediction.





